### PR TITLE
Add AWSKMSClient describe key API and more

### DIFF
--- a/tests/test_kms.py
+++ b/tests/test_kms.py
@@ -77,7 +77,7 @@ def test_aws_describe_key(aws_kms_client, aws_kms_key):
     assert "AWSAccountId" in response
 
 
-def test_aws_describe_key_id_required(aws_kms_client, aws_kms_key):
+def test_aws_describe_key_id_required(aws_kms_client):
     """AWSKMSClient update_key_description requires key_id."""
     with pytest.raises(ValueError) as exc_info:
         aws_kms_client.describe_key()
@@ -97,9 +97,27 @@ def test_aws_update_key_description(aws_kms_client, aws_kms_key):
     )
 
 
-def test_aws_update_key_desc_id_required(aws_kms_client, aws_kms_key):
+def test_aws_update_key_desc_id_required(aws_kms_client):
     """AWSKMSClient update_key_description requires key_id."""
     with pytest.raises(ValueError) as exc_info:
         aws_kms_client.update_key_description("New description")
+
+    assert str(exc_info.value) == "A key_id must be provided."
+
+
+def test_aws_disable_key(aws_kms_client, aws_kms_key):
+    """AWSKMSClient disable_key disables KMS key."""
+    key_id = aws_kms_key
+    aws_kms_client.key_id = key_id
+    aws_kms_client.boto3_client.disable_key = Mock()
+    aws_kms_client.disable_key()
+
+    aws_kms_client.boto3_client.disable_key.assert_called_once_with(KeyId=key_id)
+
+
+def test_aws_disable_key_id_required(aws_kms_client):
+    """AWSKMSClient disable_key requires key_id."""
+    with pytest.raises(ValueError) as exc_info:
+        aws_kms_client.disable_key()
 
     assert str(exc_info.value) == "A key_id must be provided."

--- a/valigetta/kms.py
+++ b/valigetta/kms.py
@@ -101,3 +101,10 @@ class AWSKMSClient(KMSClient):
         self.boto3_client.update_key_description(
             KeyId=self._ensure_key_id(), Description=description
         )
+
+    def disable_key(self):
+        """Sets the state of a KMS key to disabled
+
+        Prevents use of the KMS key.
+        """
+        self.boto3_client.disable_key(KeyId=self._ensure_key_id())


### PR DESCRIPTION
Add `describe_key`, `update_key_description` and `disable_key` APIs for AWSKMSClient