### PR TITLE
Expose important private methods

### DIFF
--- a/tests/test_decryptor.py
+++ b/tests/test_decryptor.py
@@ -10,9 +10,9 @@ from valigetta.decryptor import (
     _get_submission_iv,
     decrypt_file,
     decrypt_submission,
-    extract_dec_aes_key,
     extract_encrypted_aes_key,
     extract_instance_id,
+    extract_n_decrypt_aes_key,
 )
 from valigetta.exceptions import InvalidSubmission
 
@@ -238,7 +238,7 @@ def test_extract_dec_aes_key(
     """Extraction and decryption of AES key is successful."""
     aws_kms_client.key_id = aws_kms_key
     plaintext_aes_key, _ = fake_aes_key
-    aes_key = extract_dec_aes_key(aws_kms_client, fake_submission_xml)
+    aes_key = extract_n_decrypt_aes_key(aws_kms_client, fake_submission_xml)
 
     assert aes_key == plaintext_aes_key
 

--- a/valigetta/decryptor.py
+++ b/valigetta/decryptor.py
@@ -121,7 +121,7 @@ def decrypt_file(
         yield cipher_aes.decrypt(chunk)
 
 
-def extract_dec_aes_key(kms_client: KMSClient, submission_xml: BytesIO) -> bytes:
+def extract_n_decrypt_aes_key(kms_client: KMSClient, submission_xml: BytesIO) -> bytes:
     """Extract encrypted AES key from submission XML and decrypt it
 
     :param kms_client: KMSClient instance
@@ -148,7 +148,7 @@ def decrypt_submission(
     :param encrypted_files: An iterable yielding encrypted file contents
     :return: A generator yielding decrypted data chunks
     """
-    aes_key = extract_dec_aes_key(kms_client, submission_xml)
+    aes_key = extract_n_decrypt_aes_key(kms_client, submission_xml)
     instance_id = extract_instance_id(submission_xml)
 
     with ThreadPoolExecutor() as executor:


### PR DESCRIPTION
Expose `decrypt_file`, `extract_n_decrypt_aes_key`, `extract_encrypted_aes_key` and `extract_instance_id`. The methods are important for use cases where `decrypt_submission` might not suffice and the consumer wants fine grained control over the decryption process.