### PR TITLE
Fix incorrect computation of IV counter

### DIFF
--- a/tests/test_decryptor.py
+++ b/tests/test_decryptor.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, call
 
 import pytest
 from Crypto.Cipher import AES
+from Crypto.Util.Padding import pad
 
 from valigetta.decryptor import (
     _get_submission_iv,
@@ -144,7 +145,8 @@ def encrypt_submission(fake_aes_key):
             iv_counter=iv_counter,
         )
         cipher_aes = AES.new(plaintext_aes_key, AES.MODE_CFB, iv=iv, segment_size=128)
-        return BytesIO(cipher_aes.encrypt(original_data))
+        padded_data = pad(original_data, AES.block_size)
+        return BytesIO(cipher_aes.encrypt(padded_data))
 
     return _encrypt
 

--- a/valigetta/decryptor.py
+++ b/valigetta/decryptor.py
@@ -11,6 +11,7 @@ from io import BytesIO
 from typing import Iterable, Iterator, List, Optional, Tuple
 
 from Crypto.Cipher import AES
+from Crypto.Util.Padding import unpad
 
 from valigetta.exceptions import InvalidSubmission
 from valigetta.kms import KMSClient
@@ -191,8 +192,9 @@ def decrypt_file(
     logger.debug("Generating IV for iv_counter %d", iv_counter)
     iv = _get_submission_iv(instance_id, aes_key, iv_counter)
     cipher_aes = AES.new(aes_key, AES.MODE_CFB, iv=iv, segment_size=128)
-
-    return cipher_aes.decrypt(file.read())
+    decrypted = cipher_aes.decrypt(file.read())
+    # Strip any PKCS5/PKCS7 padding
+    return unpad(decrypted, AES.block_size)
 
 
 def decrypt_submission(


### PR DESCRIPTION
Media files should be processed first with initialization vector counter starting at 1, then submission file is processed last
Strip PKCS5/PKCS7 padding