### PR TITLE
Fix coverage badge already exists CI error

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -60,7 +60,9 @@ jobs:
 
       - name: Generate coverage badge
         if: github.ref == 'refs/heads/main'
-        run: coverage-badge -o coverage.svg
+        run: |
+          rm -f coverage.svg
+          coverage-badge -o coverage.svg
 
       - name: Check if coverage.svg changed
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
Remove badge on the runner pod before trying to regenerate. Fixes CI error https://github.com/onaio/valigetta/actions/runs/14748868448/job/41401483861