### PR TITLE
Fix build warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,14 +7,13 @@ name = "valigetta"
 description = "A Python SDK for managing encryption keys and decrypting ODK submissions."
 readme = "README.md"
 requires-python = ">=3.10"
-license = { text = "GPL-3.0-or-later" }
+license = "GPL-3.0-or-later"
 authors = [
   { name = "Ona Systems Inc.", email = "tech@ona.io" }
 ]
 urls = { Homepage = "https://github.com/onaio/valigetta" }
 classifiers = [
   "Programming Language :: Python :: 3",
-  "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
   "Operating System :: OS Independent"
 ]
 dynamic = ["version"]


### PR DESCRIPTION
use a string instead of a TOML table
delete license classifier since SPDX license is used