### PR TITLE
fix: catch error resulting from incorrect padding

### DIFF
--- a/tests/test_decryptor.py
+++ b/tests/test_decryptor.py
@@ -401,6 +401,25 @@ def test_decrypt_file(fake_aes_key, encrypt_submission):
     assert dec_file == original_data
 
 
+@patch("valigetta.decryptor.unpad")
+def test_decrypt_file_with_invalid_padding(
+    mock_unpad, fake_aes_key, encrypt_submission
+):
+    """Decrypting a single file with invalid padding raises an error."""
+    mock_unpad.side_effect = ValueError("Invalid padding")
+
+    plaintext_aes_key, _ = fake_aes_key
+    original_data = b"A" * 10 * 1024  # 10KB of 'A' characters
+    enc_file = encrypt_submission(original_data, 1)
+
+    with pytest.raises(InvalidSubmissionException) as exc_info:
+        decrypt_file(
+            enc_file, plaintext_aes_key, "uuid:a10ead67-7415-47da-b823-0947ab8a8ef0", 1
+        )
+
+    assert str(exc_info.value) == "Invalid padding in decrypted file: Invalid padding"
+
+
 def test_extract_encrypted_signature(
     tree_encrypted_ns, fake_signature, tree_submissions_ns
 ):

--- a/valigetta/decryptor.py
+++ b/valigetta/decryptor.py
@@ -196,7 +196,12 @@ def decrypt_file(
     cipher_aes = AES.new(aes_key, AES.MODE_CFB, iv=iv, segment_size=128)
     decrypted = cipher_aes.decrypt(file.read())
     # Strip any PKCS5/PKCS7 padding
-    return unpad(decrypted, AES.block_size)
+    try:
+        return unpad(decrypted, AES.block_size)
+    except ValueError as exc:
+        raise InvalidSubmissionException(
+            f"Invalid padding in decrypted file: {exc}"
+        ) from exc
 
 
 def decrypt_submission(


### PR DESCRIPTION
`ValueError` raised from incorrect padding was not caught as `InvalidSubmissionException` by a caller of `valigetta.decryptor.decrypt_submission`